### PR TITLE
Fix behavior when the number of groups decreases

### DIFF
--- a/airtable.py
+++ b/airtable.py
@@ -31,6 +31,12 @@ class AirtableClient(object):
                  'Content-Type': 'application/json'}
         return requests.put(url, headers=headers, json=data)
 
+    def _DeleteAirtable(self, url_path):
+        url = "https://api.airtable.com/v0/" + self.base + "/" + url_path
+        headers = {'Authorization': 'Bearer ' + self.key,
+                 'Content-Type': 'application/json'}
+        return requests.delete(url, headers=headers)
+
     def _LoadTable(self, table, construct):
       records = []
       response = self._GetAirtable(table)
@@ -89,6 +95,18 @@ class AirtableClient(object):
         print(record)
         resp = self._PostAirtable('Rosters', { 'records': [record] })
         print(resp.content)
+
+    def DeleteRoster(self, roster, rides):
+      ride_to_id = {}
+      for r in rides:
+        ride_to_id[r.num] = r.airtable_id
+
+      if roster.finalized:
+        print('Skipping finalized roster: ', r.id)
+        return
+      assert(len(roster.id) > 0)
+      print('Deleting %s' % roster.id)
+      self._DeleteAirtable('Rosters/%s' % roster.id)
 
 def _LoadAvailability(rider, json):
   if 'Availability' in json['fields']:

--- a/main.py
+++ b/main.py
@@ -48,6 +48,13 @@ def run_algorithm(config, publish=False):
 
     for ride in range(params.start_ride, params.num_rides):
         ride_rosters = Rosters(r for r in rosters if r.ride == ride)
+        ride_prior_rosters = Rosters(r for r in prior_rosters if r.ride == ride)
+
+        print('Ride %d - modeled %d rosters, previously %d rosters' %
+              (ride, ride_rosters.NumRosters(), ride_prior_rosters.NumRosters()))
+        for roster in ride_prior_rosters.rosters[ride_rosters.NumRosters():]:
+            airtable_client.DeleteRoster(roster, rides)
+
         for roster in ride_rosters.rosters:
             airtable_client.CreateRoster(roster, rides)
         slack_client.PostRoster(ride_rosters)

--- a/ride.py
+++ b/ride.py
@@ -57,6 +57,9 @@ class Rosters(object):
             self.ride = r.ride
             break
 
+    def NumRosters(self):
+        return len(self.rosters)
+
     def SlackBlocks(self, image_id=None):
         s = '\n'.join(str(s) for s in self.rosters)
         finalized_msg = f":computer: These rosters are a *DRAFT* (last updated {datetime.now()})."


### PR DESCRIPTION
Previously records were only updated or added in Airtable when writes were made, there was no mechanism for deleting records.  This behavior was a bug when the number of groups for a ride would decrease.  (It caused the Slack posts to contain stale groups in addition to updated groups.)